### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Docker Image CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Merilairon/colruyt-scraper/security/code-scanning/1](https://github.com/Merilairon/colruyt-scraper/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block in the workflow (either at the root or per job) that grants only the minimal rights required. For simple build-and-push workflows that only need to read the repository content and don’t need to modify GitHub resources, `contents: read` is typically sufficient.

For this specific workflow in `.github/workflows/docker-image.yml`, the best fix without changing existing functionality is:
- Add a workflow-level `permissions` block immediately after the `name:` declaration (or after `on:`; either is valid) so it applies to all jobs.
- Set `contents: read` as a minimal starting point, consistent with the CodeQL suggestion and the workflow’s apparent needs (checkout code, build image, push to Docker Hub via secrets).

No additional imports or external dependencies are required; this is purely a YAML configuration change in the workflow file. No changes to steps, actions, or secrets are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
